### PR TITLE
downgrade minitest from 5.11.3 to 4.2.0

### DIFF
--- a/yelp-fusion.gemspec
+++ b/yelp-fusion.gemspec
@@ -41,5 +41,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '~> 0.15.2'
   spec.add_dependency 'faraday_middleware', '~> 0.12.2'
-  spec.add_dependency 'minitest', '>= 5.11.3'
+  spec.add_dependency 'minitest', '>= 4.2.0'
 end


### PR DESCRIPTION
- updates `yelp-fusion-gemspec` to include `minitest 4.2.0` rather than `minitest 5.11.3`