### PR TITLE
Adds singleton methods to Client class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,19 @@ Please remember to read and follow the [Terms of Use](https://www.yelp.com/devel
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Add this line to your Rails application's Gemfile:
 
 ```ruby
 gem 'yelp-fusion', '0.2.1-beta'
 ```
+
+Add this line to your Ruby appliation's Gemfile:
+
+```ruby
+gem 'yelp-fusion', require: 'yelp/fusion'
+```
+
+
 
 And then execute:
 
@@ -98,7 +106,7 @@ client.phone_search('+15555555555')
 
 ### [Review Details API](https://www.yelp.com/developers/documentation/v3/business_reviews)
 
-To find all of the reviews for a business, use ``#review`` with a business ID. 
+To find all of the reviews for a business, use ``#review`` with a business ID.
 
 ```ruby
 client.review('lJAGnYzku5zSaLnQ_T6_GQ')
@@ -106,7 +114,7 @@ client.review('lJAGnYzku5zSaLnQ_T6_GQ')
 
 ### [Transaction Details API](https://www.yelp.com/developers/documentation/v3/transaction_search)
 
-To find all of the reviews for a business, use ``#transaction`` with ``'deliver'`` and a business ID. 
+To find all of the reviews for a business, use ``#transaction`` with ``'deliver'`` and a business ID.
 
 ```ruby
 client.transaction_search('delivery', {location: 'San Francisco'})
@@ -114,7 +122,7 @@ client.transaction_search('delivery', {location: 'San Francisco'})
 
 ### [Match Details API](https://www.yelp.com/developers/documentation/v3/business_match)
 
-To find all of the reviews for a business, use ``#match`` with a business ID. 
+To find all of the reviews for a business, use ``#match`` with a business ID.
 
 ```ruby
 client.match({name: 'swissbakers', address1: '168 Western Ave', city: 'allston', state: 'MA', country: 'US'})

--- a/lib/yelp/fusion.rb
+++ b/lib/yelp/fusion.rb
@@ -1,4 +1,4 @@
-# Copyright (c) Jobcase, Inc. All rights reserved. 
+# Copyright (c) Jobcase, Inc. All rights reserved.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/yelp/fusion/client.rb
+++ b/lib/yelp/fusion/client.rb
@@ -1,4 +1,4 @@
-# Copyright (c) Jobcase, Inc. All rights reserved. 
+# Copyright (c) Jobcase, Inc. All rights reserved.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -27,10 +27,12 @@ require 'yelp/fusion/endpoint/business'
 require 'yelp/fusion/endpoint/phone'
 require 'yelp/fusion/endpoint/match'
 require 'yelp/fusion/endpoint/transaction'
+require 'yelp/fusion/singleton'
 
 module Yelp
   module Fusion
     class Client
+      include Fusion::Singleton
       API_HOST = 'https://api.yelp.com'.freeze
 
       attr_accessor :configuration
@@ -38,8 +40,10 @@ module Yelp
       # Creates an instance of the fusion client
       # @param options [String, nil] a consumer key
       # @return [Client] a new client initialized with the keys
+
       def initialize(option = nil)
         @configuration = nil
+        define_request_methods
         return if option.nil?
         @configuration = Configuration.new(option)
       end

--- a/lib/yelp/fusion/singleton.rb
+++ b/lib/yelp/fusion/singleton.rb
@@ -4,7 +4,7 @@ module Yelp
       # These methods were copied from the old yelp implementation
       # https://github.com/Yelp/yelp-ruby
 
-      REQUEST_CLASSES = [ Yelp::Fusion::Endpoint::Search,
+      REQUEST_CLASSES = [Yelp::Fusion::Endpoint::Search,
                         Yelp::Fusion::Endpoint::Business,
                         Yelp::Fusion::Endpoint::Phone]
         private

--- a/lib/yelp/fusion/singleton.rb
+++ b/lib/yelp/fusion/singleton.rb
@@ -19,7 +19,6 @@ module Yelp
           end
         end
 
-        # yelp
         # Loop through all of the endpoint instances' public singleton methods to
         # add the method to client
         def create_methods_from_instance(instance)
@@ -28,7 +27,6 @@ module Yelp
           end
         end
 
-        # yelp
         # Define the method on the client and send it to the endpoint instance
         # with the args passed in
         def add_method(instance, method_name)

--- a/lib/yelp/fusion/singleton.rb
+++ b/lib/yelp/fusion/singleton.rb
@@ -1,0 +1,41 @@
+module Yelp
+  module Fusion
+    module Singleton
+      # These methods were copied from the old yelp implementation
+      # https://github.com/Yelp/yelp-ruby
+
+      REQUEST_CLASSES = [ Yelp::Fusion::Endpoint::Search,
+                        Yelp::Fusion::Endpoint::Business,
+                        Yelp::Fusion::Endpoint::Phone]
+        private
+
+        # This goes through each endpoint class and creates singletone methods
+        # on the client that query those classes. We do this to avoid possible
+        # namespace collisions in the future when adding new classes
+        def define_request_methods
+          REQUEST_CLASSES.each do |request_class|
+            endpoint_instance = request_class.new(self)
+            create_methods_from_instance(endpoint_instance)
+          end
+        end
+
+        # yelp
+        # Loop through all of the endpoint instances' public singleton methods to
+        # add the method to client
+        def create_methods_from_instance(instance)
+          instance.public_methods(false).each do |method_name|
+            add_method(instance, method_name)
+          end
+        end
+
+        # yelp
+        # Define the method on the client and send it to the endpoint instance
+        # with the args passed in
+        def add_method(instance, method_name)
+          define_singleton_method(method_name) do |*args|
+            instance.public_send(method_name, *args)
+          end
+        end
+    end
+  end
+end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) Jobcase, Inc. All rights reserved. 
+# Copyright (c) Jobcase, Inc. All rights reserved.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -88,5 +88,20 @@ class ClientTest < Minitest::Test
     assert_raises Yelp::Fusion::Error::MissingAPIKeys do
       @client.connection
     end
+  end
+
+  def test_if_responds_to_search_method
+    client = Yelp::Fusion::Client.new('api_key')
+    assert client.respond_to?(:search)
+  end
+
+  def test_if_responds_to_bussines_method
+    client = Yelp::Fusion::Client.new('api_key')
+    assert client.respond_to?(:business)
+  end
+
+  def test_if_responds_to_phone_search_method
+    client = Yelp::Fusion::Client.new('api_key')
+    assert client.respond_to?(:phone_search)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-# Copyright (c) Jobcase, Inc. All rights reserved. 
+# Copyright (c) Jobcase, Inc. All rights reserved.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -19,7 +19,9 @@
 # THE SOFTWARE.
 
 require 'simplecov'
-SimpleCov.start
+SimpleCov.start do
+  add_filter "/\.bundle/"
+end
 
 require 'yelp/fusion'
 require 'yelp/fusion/client'

--- a/yelp-fusion.gemspec
+++ b/yelp-fusion.gemspec
@@ -37,6 +37,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.11.3'
   spec.add_development_dependency 'pry-coolline', '~> 0.2.5'
   spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'simplecov', '~> 0.16.0'
+  spec.add_development_dependency 'vcr', '~> 4.0'
+  spec.add_development_dependency 'faraday_middleware', '~> 0.12.2'
+  spec.add_development_dependency 'rubocop', '~> 0.58'
+  spec.add_development_dependency 'webmock', '~> 3.4.2'
 
   spec.add_dependency 'faraday', '~> 0.15.2'
   spec.add_dependency 'faraday_middleware', '~> 0.12.2'


### PR DESCRIPTION
#### what?
Adds backward compatibility with old yelp gem.

Adds singleton methods to client instance object ensuring that only this object can query the endpoints. 


* Adds Endpoints(Search, Business, Phone) singleton methods to Client class instance
* Extracts singleton into a module


#### why?

Old yelp gem supports these queries.

```ruby
  client =. Yelp::Client.new(YOUR_API_KEY)
  client.search('San Francisco')
  client.search_by_coordinates(coordinates, params, locale)
  client.business('yelp-san-francisco')
  client.phone_search('+15555555555')
```

#### issue related

https://github.com/erikgrueter1/yelp-fusion/issues/5